### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then, we suggest to use a virtual environment to install the dependencies.
 ```bash
 micromamba create -n mesh_splatting python=3.11
 micromamba activate mesh_splatting
-micromamba install nvidia/label/cuda-12.6.0::cuda
+micromamba install --channel-priority flexible nvidia/label/cuda-12.6.0::cuda
 
 pip install torch==2.7.1 torchvision==0.22.1
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ plyfile
 mediapy
 opencv-python
 matplotlib
+setuptools==65.0.0
 tqdm 
 trimesh
 mmengine


### PR DESCRIPTION
- 45d6073 Fix installation instructions
  
  * Solving the environment fails without `--channel-priority flexible`.
  * Installing mmcv requires a certain (older) version of setuptools.

Tested on Ubuntu 26.04.